### PR TITLE
chore: bump Node.js version to 22

### DIFF
--- a/.github/workflows/ci-on-pull-request.yml
+++ b/.github/workflows/ci-on-pull-request.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [20]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
     needs: setup-dependencies
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [20]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
     needs: setup-dependencies
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [20]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci-on-pull-request.yml
+++ b/.github/workflows/ci-on-pull-request.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
     needs: setup-dependencies
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
     needs: setup-dependencies
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 20
+nodejs 22
 pnpm 10

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This application is a tool for DJs and music producers to calculate the tempo of
 ## Development
 
 ### Prerequisites
-- Node.js 18+ 
+- Node.js 22+
 - pnpm (recommended) or npm/yarn
 
 ### Getting Started

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.4.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/react": "^18.3.2",
     "@types/react-dom": "^18.2.22",
-    "@types/node": "^20.12.12",
+    "@types/node": "^22.19.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "@vitejs/plugin-react": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@types/node':
-        specifier: ^20.12.12
-        version: 20.19.4
+        specifier: ^22.19.0
+        version: 22.19.0
       '@types/react':
         specifier: ^18.3.2
         version: 18.3.20
@@ -35,7 +35,7 @@ importers:
         version: 5.62.0(eslint@8.57.1)(typescript@5.8.2)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.6.0(vite@5.4.19(@types/node@20.19.4)(terser@5.39.0))
+        version: 4.6.0(vite@5.4.19(@types/node@22.19.0)(terser@5.39.0))
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.21(postcss@8.5.6)
@@ -59,10 +59,10 @@ importers:
         version: 5.8.2
       vite:
         specifier: ^5.0.8
-        version: 5.4.19(@types/node@20.19.4)(terser@5.39.0)
+        version: 5.4.19(@types/node@22.19.0)(terser@5.39.0)
       vite-plugin-pwa:
         specifier: ^0.17.0
-        version: 0.17.5(vite@5.4.19(@types/node@20.19.4)(terser@5.39.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0)
+        version: 0.17.5(vite@5.4.19(@types/node@22.19.0)(terser@5.39.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0)
       workbox-build:
         specifier: ^7.0.0
         version: 7.3.0(@types/babel__core@7.20.5)
@@ -996,8 +996,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@20.19.4':
-    resolution: {integrity: sha512-OP+We5WV8Xnbuvw0zC2m4qfB/BJvjyCwtNjhHdJxV1639SGSKrLmJkc3fMnp2Qy8nJyHp8RO6umxELN/dS1/EA==}
+  '@types/node@22.19.0':
+    resolution: {integrity: sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA==}
 
   '@types/prop-types@15.7.14':
     resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
@@ -3574,7 +3574,7 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@20.19.4':
+  '@types/node@22.19.0':
     dependencies:
       undici-types: 6.21.0
 
@@ -3681,7 +3681,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.6.0(vite@5.4.19(@types/node@20.19.4)(terser@5.39.0))':
+  '@vitejs/plugin-react@4.6.0(vite@5.4.19(@types/node@22.19.0)(terser@5.39.0))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
@@ -3689,7 +3689,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.19
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 5.4.19(@types/node@20.19.4)(terser@5.39.0)
+      vite: 5.4.19(@types/node@22.19.0)(terser@5.39.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5209,24 +5209,24 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-plugin-pwa@0.17.5(vite@5.4.19(@types/node@20.19.4)(terser@5.39.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0):
+  vite-plugin-pwa@0.17.5(vite@5.4.19(@types/node@22.19.0)(terser@5.39.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0):
     dependencies:
       debug: 4.4.0
       fast-glob: 3.3.3
       pretty-bytes: 6.1.1
-      vite: 5.4.19(@types/node@20.19.4)(terser@5.39.0)
+      vite: 5.4.19(@types/node@22.19.0)(terser@5.39.0)
       workbox-build: 7.3.0(@types/babel__core@7.20.5)
       workbox-window: 7.3.0
     transitivePeerDependencies:
       - supports-color
 
-  vite@5.4.19(@types/node@20.19.4)(terser@5.39.0):
+  vite@5.4.19(@types/node@22.19.0)(terser@5.39.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.44.2
     optionalDependencies:
-      '@types/node': 20.19.4
+      '@types/node': 22.19.0
       fsevents: 2.3.3
       terser: 5.39.0
 


### PR DESCRIPTION
## Summary
- update tooling configuration to require Node.js 22
- refresh dev dependency metadata and documentation for the new runtime

## Testing
- pnpm build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d5d5db408325adc6e300778f0aa3)